### PR TITLE
Make database type schema agnostic

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "mysql-queue",
   "description": "A lite job queue for Node.js",
   "author": "lilac <hi@rabain.com>",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -10,7 +10,7 @@ export const affectedRows = (rawResult: MySqlRawQueryResult) => {
     return rawResult[0].affectedRows
 };
 
-export async function connect(url: string) {
+export function connect(url: string) {
     const connection = mysql.createPool(url);
     const db = drizzle(connection, { schema, mode: 'default' });
     return db;

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -11,7 +11,7 @@ export const affectedRows = (rawResult: MySqlRawQueryResult) => {
 };
 
 export async function connect(url: string) {
-    const connection = await mysql.createConnection(url);
+    const connection = mysql.createPool(url);
     const db = drizzle(connection, { schema, mode: 'default' });
     return db;
 }

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -4,7 +4,7 @@ import mysql from "mysql2/promise";
 import path from "node:path";
 import * as schema from "./schema";
 
-export type Database = MySql2Database<typeof schema>;
+export type Database = MySql2Database<Record<string, unknown>>;
 
 export const affectedRows = (rawResult: MySqlRawQueryResult) => {
     return rawResult[0].affectedRows
@@ -16,7 +16,7 @@ export async function connect(url: string) {
     return db;
 }
 
-export function migrateDB(db: MySql2Database<Record<string, unknown>>) {
+export function migrateDB(db: Database) {
     return migrate(db, {
         migrationsFolder: path.join(import.meta.dirname, '../drizzle')
     });

--- a/src/test.ts
+++ b/src/test.ts
@@ -5,7 +5,7 @@ const defaultUrl = env['DATABASE_URL'] ?? 'mysql://root:root@localhost:3306/queu
 
 
 async function prepareDB(url?: string) {
-  const db = await connect(url ?? defaultUrl);
+  const db = connect(url ?? defaultUrl);
   await migrateDB(db);
   return db;
 }


### PR DESCRIPTION
so that clients of this library does not need to import `schema`.